### PR TITLE
Remove timeout from database connection attempts

### DIFF
--- a/db-check
+++ b/db-check
@@ -37,13 +37,8 @@ if (
             print('- Database available - continuing')
             sys.exit(0)
         except OperationalError:
-            if time_spent < 20:
-                time.sleep(1)
-                time_spent += 1
-            else:
-                print('- Failed to connect - giving up')
-                sys.exit(9)
-
+            time.sleep(1)
+            time_spent += 1
 
 else:
     print('Database not configured - skipping')

--- a/entrypoint
+++ b/entrypoint
@@ -26,19 +26,7 @@ if ! python -c "import django"; then
     exit 1
 fi
 
-# Wait for database to come up
-echo "execfile('/db-check')" | ./manage.py shell -i bpython 2> /tmp/dberror || db_error=$?
 
-DATABASE=true
-
-if [ -n "${db_error:-}" ]; then
-    if [ $db_error -eq 9 ]; then
-        DATABASE=false
-    else
-        cat /tmp/dberror
-        exit 1
-    fi
-fi
 
 # Run manage.py commands
 if [ -n "$run_command" ]; then
@@ -46,9 +34,14 @@ if [ -n "$run_command" ]; then
     python manage.py $run_command
 else
     # By default, prepare database and run server
-    if $DATABASE; then
+    if echo "execfile('/db-check')" | ./manage.py shell -i bpython 2> /tmp/dberror; then
+        # Wait for database to come up before running migrate
         python manage.py migrate --noinput
+    else
+        # If we encountered an unrecognised error, print it and exit
+        if [ $? -ne 9 ]; then cat /tmp/dberror && exit 1; fi
     fi
+
     python manage.py runserver 0.0.0.0:${PORT}
 fi
 


### PR DESCRIPTION
If we know there's a database, we should try to connect to it indefinitely, as we will always want a database.

This is assuming that the method for checking if a database is necessary is fool-proof. But I think we should assume it is, until proven otherwise.

QA
--

``` bash
docker build . -t django
git clone https://github.com/canonical-websites/partners.ubuntu.com
cd partners.ubuntu.com
```

Now edit the `run` script and swap out `ubuntudesign/django:1.2.1` for `django`.

Now run it with `./run` and check the site runs okay.

Now edit the `run` script again and comment out line 151 so it looks like this (so it won't spin up the database):

``` bash
  # First run the database
  #docker_db
```

Now run `./run` again. Check it tries to connect to the database forever until you press CTRL+c.