### PR TITLE
Use python3 instead of python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3-alpine
 
 # Expect to find the entrypoint script at /entrypoint
 ENTRYPOINT ["/entrypoint"]
@@ -8,14 +8,15 @@ ENV DB_HOST="db"
 ENV DB_PORT="5432"
 
 # Debug tools
-RUN pip install ipdb
+RUN apk add --no-cache build-base linux-headers libffi-dev libffi-dev openssl-dev postgresql-dev libxml2-dev libxslt-dev python3-dev
+RUN pip3 install ipdb
 
 # Default config for where we expect to find requirements
 ENV REQUIREMENTS_PATH="requirements.txt"
-ENV REQUIREMENTS_HASH="/usr/local/lib/python2.7/site-packages/requirements.md5"
+ENV REQUIREMENTS_HASH="/usr/local/lib/python3.6/site-packages/requirements.md5"
 
 # Ensure all users can create dependencies
-RUN chmod -R 777 /usr/local/lib/python2.7/site-packages/ /usr/local/bin/ /usr/local/share/
+RUN chmod -R 777 /usr/local/lib/python3.6/site-packages/ /usr/local/bin/ /usr/local/share/
 
 # Create a shared home directory
 # This helps anonymous users have a home
@@ -26,4 +27,3 @@ RUN chmod -R 777 $HOME
 # Add binaries to image
 ADD entrypoint /entrypoint
 ADD db-check   /db-check
-

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A docker image for running Django projects in local development, where they corr
 This image is meant for running Django projects which:
 
 - Define all required dependencies in `./requirements.txt`
-- Are compatible with Python 2 (python 3 support on its way)
+- Are compatible with Python 3
 
 ## Usage
 
@@ -43,7 +43,7 @@ The above command works but will install requirements from scratch every time it
 $ docker run -ti \
          --volume `pwd`:`pwd`  \
          --workdir `pwd`  \
-         --volume dependencies:/usr/local/lib/python2.7/site-packages  \
+         --volume dependencies:/usr/local/lib/python3.6/site-packages  \
          --publish 8000:8000  \
          ubuntudesign/django-app
 ```
@@ -63,7 +63,7 @@ A standard `docker-compose.yml` for the `django-app` image:
 webapp:
     image: ubuntudesign/django-app::v1.0.8
     volumes:
-      - "dependencies:/usr/local/lib/python2.7/site-packages"
+      - "dependencies:/usr/local/lib/python3.6/site-packages"
       - .:/app
     working_dir: /app
     ports:
@@ -86,7 +86,7 @@ Here's an example of a `docker-compose.yml` with a PostgreSQL database:
 webapp:
   image: ubuntudesign/django-app:v1.0.8
   volumes:
-    - "dependencies:/usr/local/lib/python2.7/site-packages"
+    - "dependencies:/usr/local/lib/python3.6/site-packages"
     - .:/app
   working_dir: /app
   ports:
@@ -114,7 +114,8 @@ docker run -ti  \
        --env DB_HOST=postgres_db  \
        --volume `pwd`:`pwd`  \
        --workdir `pwd`  \
-       --volume dependencies:/usr/local/lib/python2.7/site-packages  \
+       --volume dependencies:/usr/local/lib/python3.6/site-packages  \
        --publish 8000:8000  \
        ubuntudesign/django-app
 ```
+

--- a/db-check
+++ b/db-check
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Core modules
 import sys

--- a/entrypoint
+++ b/entrypoint
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 set -euo pipefail
 
@@ -13,7 +13,7 @@ run_command=$@
 if [ -f $REQUIREMENTS_PATH ]; then
     if [[ ! -f "${REQUIREMENTS_HASH}" ]] || [[ "$(cat ${REQUIREMENTS_HASH})" != $(md5sum $REQUIREMENTS_PATH) ]]; then
         echo "Installing python modules." >> /dev/stderr
-        pip install --requirement $REQUIREMENTS_PATH  # Install new dependencies
+        pip3 install --requirement $REQUIREMENTS_PATH  # Install new dependencies
         md5sum $REQUIREMENTS_PATH > $REQUIREMENTS_HASH
     fi
 else
@@ -21,7 +21,7 @@ else
 fi
 
 # Check for Django
-if ! python -c "import django"; then
+if ! python3 -c "import django"; then
     echo "Error: Django not found." >> /dev/stderr
     exit 1
 fi
@@ -31,17 +31,16 @@ fi
 # Run manage.py commands
 if [ -n "$run_command" ]; then
     # If we have arguments, pass them to manage.py
-    python manage.py $run_command
+    python3 manage.py $run_command
 else
     # By default, prepare database and run server
-    if echo "execfile('/db-check')" | ./manage.py shell -i bpython 2> /tmp/dberror; then
+    if echo "exec(open('/db-check').read())" | python3 manage.py shell -i bpython 2> /tmp/dberror; then
         # Wait for database to come up before running migrate
-        python manage.py migrate --noinput
+        python3 manage.py migrate --noinput
     else
         # If we encountered an unrecognised error, print it and exit
         if [ $? -ne 9 ]; then cat /tmp/dberror && exit 1; fi
     fi
 
-    python manage.py runserver 0.0.0.0:${PORT}
+    python3 manage.py runserver 0.0.0.0:${PORT}
 fi
-

--- a/entrypoint
+++ b/entrypoint
@@ -11,7 +11,7 @@ run_command=$@
 
 # Update any python requirements
 if [ -f $REQUIREMENTS_PATH ]; then
-    if [[ ! -f "${REQUIREMENTS_HASH}" ]] || [[ "$(cat ${REQUIREMENTS_HASH})" != $(md5sum $REQUIREMENTS_PATH) ]]; then
+    if [ ! -f "${REQUIREMENTS_HASH}" ] || [ "$(cat ${REQUIREMENTS_HASH})" != "$(md5sum $REQUIREMENTS_PATH)" ]; then
         echo "Installing python modules." >> /dev/stderr
         pip3 install --requirement $REQUIREMENTS_PATH  # Install new dependencies
         md5sum $REQUIREMENTS_PATH > $REQUIREMENTS_HASH


### PR DESCRIPTION
QA
--

Try using this image to run www.canonical.com:

``` bash
# Build this image as "django-python3"
docker build -t django-python3 .

# Get www.canonical.com (which uses python3)
git clone https://github.com/canonical-websites/www.canonical.com
cd www.canonical.com

# Run with this image
docker run -ti --volume `pwd`:`pwd` --workdir `pwd` --publish 8000:8000 django-python3
```

Now browse to <http://127.0.0.1:8000> and see it serves canonical.com - but note that the CSS won't have been built etc. - it's just running Django.

For extra marks, try going through all the steps mentioned in the README for different ways of running the site.